### PR TITLE
Support injecting of dependencies into module

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,13 @@ function cacheTranslations(options) {
 }
 
 function wrapTranslations(options) {
+  var dependencies = options.dependencies.constructor && options.dependencies.constructor == Array ? options.dependencies.toString() : '[]';
   return es.map(function(file, callback) {
     file.contents = new Buffer(gutil.template('angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n', {
       contents: file.contents,
       file: file,
       module: options.module || 'translations',
-      standalone: options.standalone === false ? '' : ', []'
+      standalone: options.standalone === false ? '' : ', ' + dependencies
     }));
     callback(null, file);
   });


### PR DESCRIPTION
This allows me to fix the following error
```
Uncaught Error: [$injector:modulerr] Failed to instantiate module myApp.i18n due to:
Error: [$injector:unpr] Unknown provider: $translateProvider
```

Sample Usage
```javascript
angularTranslate({
  dependencies: ['pascalprecht.translate']
})
```