### PR TITLE
Added 'useFolders' option to support locales by folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,20 @@ path/en_US/messages.json | en_US
 
 > Name of AngularJS module.
 
+#### standalone - {boolean} [standalone=true]
+
+> Create a new AngularJS module, instead of using an existing.
+
 #### useFolders - {boolean} [useFolders=false]
 
 > Enables testing of folder names prior to test file path
 
 If locale couldn't be determined from folder name, filename would be tested instead.
 
-#### standalone - {boolean} [standalone=true]
+#### useStrict - {boolean} [useStrict=false]
 
-> Create a new AngularJS module, instead of using an existing.
+> Output files would have z'use strict';` statement
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ gulp-angular-translate([filename](https://github.com/RobbinHabermehl/gulp-angula
 
 ### options
 
-#### language - {string} [language=`derived from filename`]
+#### language - {string} [language=`derived from filename or folder`]
 
 > Sets the language of the matched files, derived from the filename by default:
 
@@ -77,10 +77,21 @@ en-us.json | en-us
 en_us.json | en_us
 en-US.json | en-US
 en_US.json | en_US
+path/en/messages.json | en
+path/en-us/messages.json | en-us
+path/en_us/messages.json | en_us
+path/en-US/messages.json | en-US
+path/en_US/messages.json | en_US
 
 #### module - {string} [module='translations']
 
 > Name of AngularJS module.
+
+#### useFolders - {boolean} [useFolders=false]
+
+> Enables testing of folder names prior to test file path
+
+If locale couldn't be determined from folder name, filename would be tested instead.
 
 #### standalone - {boolean} [standalone=true]
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function cacheTranslations(options) {
 
 function determineFileLanguage(filePath, options) {
   if (options.useFolders === true) {
-    var match = filePath.match(new RegExp(path.sep + '([a-z]{2}[_|-]?(?:[A-Za-z]{2})?)' + path.sep + '[^' + path.sep + ']+\.json'));
+    var match = filePath.match(new RegExp('\\' + path.sep + '([a-z]{2}[_|-]?(?:[A-Za-z]{2})?)' + '\\' + path.sep + '[^' + '\\' + path.sep + ']+\.json'));
     if (match && match.length > 0) {
       return match.pop();
     }

--- a/index.js
+++ b/index.js
@@ -8,10 +8,21 @@ function cacheTranslations(options) {
     file.contents = new Buffer(gutil.template('$translateProvider.translations("<%= language %>", <%= contents %>);\n', {
       contents: file.contents,
       file: file,
-      language: options.language || file.path.split(path.sep).pop().match(/^(?:[\w]{3,}-)?([a-z]{2}[_|-]?(?:[A-Z]{2})?)\.json$/i).pop()
+      language: options.language || determineFileLanguage(file.path, options)
     }));
     callback(null, file);
   });
+}
+
+function determineFileLanguage(filePath, options) {
+  if (options.useFolders === true) {
+    var match = filePath.match(new RegExp(path.sep + '([a-z]{2}[_|-]?(?:[A-Za-z]{2})?)' + path.sep + '[^' + path.sep + ']+\.json'));
+    if (match && match.length > 0) {
+      return match.pop();
+    }
+  }
+
+  return filePath.split(path.sep).pop().match(/^(?:[\w]{3,}-)?([a-z]{2}[_|-]?(?:[A-Z]{2})?)\.json$/i).pop();
 }
 
 function wrapTranslations(options) {

--- a/index.js
+++ b/index.js
@@ -27,11 +27,12 @@ function determineFileLanguage(filePath, options) {
 
 function wrapTranslations(options) {
   return es.map(function(file, callback) {
-    file.contents = new Buffer(gutil.template('angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n', {
+    file.contents = new Buffer(gutil.template('<%= strict %>angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n', {
       contents: file.contents,
       file: file,
       module: options.module || 'translations',
-      standalone: options.standalone === false ? '' : ', []'
+      standalone: options.standalone === false ? '' : ', []',
+      strict: options.useStrict === true ? "'use strict'; " : ''
     }));
     callback(null, file);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-angular-translate",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Concatenates and registers translations for angular-translate in an AngularJS module.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-angular-translate",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Concatenates and registers translations for angular-translate in an AngularJS module.",
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -88,6 +88,36 @@ describe('gulp-angular-translate', function () {
     cb();
   });
 
+  it('should derive the language from locale-folders', function(cb) {
+    var filenames = {
+      'path/en/locale.json': 'en',
+      'path/en-us/locale.json': 'en-us',
+      'path/en_us/locale.json': 'en_us',
+      'path/en-US/locale.json': 'en-US',
+      'path/en_US/locale.json': 'en_US'
+    };
+
+    for (var filename in filenames) {
+      var stream = angularTranslate('translations.js', {
+        useFolders: true
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(new RegExp('\\$translateProvider\\.translations\\("' + filenames[filename] + '"').test(file.contents.toString('utf8')), true);
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/' + filename,
+        contents: new Buffer('{"HEADLINE":"What an awesome module!"}')
+      }));
+
+      stream.end();      
+    }
+    
+    cb();
+  });
+
   describe('options.standalone', function () {
     it('shouldn\'t create standalone AngularJS module', function(cb) {
       var stream = angularTranslate('translations.js', {


### PR DESCRIPTION
Hi!
In our project we are splitting translations in different folders, and gulp-angular-translate didn't support this scheme.
So I made some changes to enable this support:

One option was added - `useFolders: true`
If it is set to true, language would be guessed from folder name (where json file is located)

```
path/xx-YY/msg.json -> language == ‘xx-YY’
path/zz/msg.json -> language == ‘zz’
```

Plus fixed regexp for windows machines.
