### PR TITLE
Add optional ability to set $translateProvider.preferredLanguage()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var concat = require('gulp-concat');
 var es = require('event-stream');
 var gutil = require('gulp-util');
 var path = require('path');
+var defaultTemplate = 'angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n';
+var preferredLanguageTemplate = 'angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>$translateProvider.preferredLanguage("<%= preferredLanguage %>");}]);\n';
 
 function cacheTranslations(options) {
   return es.map(function(file, callback) {
@@ -16,11 +18,12 @@ function cacheTranslations(options) {
 
 function wrapTranslations(options) {
   return es.map(function(file, callback) {
-    file.contents = new Buffer(gutil.template('angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n', {
+    file.contents = new Buffer(gutil.template((options.preferredLanguage) ? preferredLanguageTemplate : defaultTemplate, {
       contents: file.contents,
       file: file,
       module: options.module || 'translations',
-      standalone: options.standalone === false ? '' : ', []'
+      standalone: options.standalone === false ? '' : ', []',
+      preferredLanguage: options.preferredLanguage
     }));
     callback(null, file);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -112,7 +112,7 @@ describe('gulp-angular-translate', function () {
   });
 
   describe('options.preferredLanguage', function () {
-    it('should set a the preferred language', function(cb) {
+    it('should set the preferred language', function(cb) {
       var stream = angularTranslate({
         preferredLanguage: 'en'
       });

--- a/test/test.js
+++ b/test/test.js
@@ -111,6 +111,29 @@ describe('gulp-angular-translate', function () {
     });
   });
 
+  describe('options.preferredLanguage', function () {
+    it('should set a the preferred language', function(cb) {
+      var stream = angularTranslate({
+        preferredLanguage: 'en'
+      });
+
+      stream.on('data', function (file) {
+        assert.equal(path.normalize(file.path), path.normalize(__dirname + '/translations.js'));
+        assert.equal(file.relative, 'translations.js');
+        assert.equal(file.contents.toString('utf8'), 'angular.module("translations", []).config(["$translateProvider", function($translateProvider) {\n$translateProvider.translations("en", {\"HEADLINE\":\"What an awesome module!\"});\n$translateProvider.preferredLanguage("en");}]);\n');
+        cb();
+      });
+
+      stream.write(new gutil.File({
+        base: __dirname,
+        path: __dirname + '/locale-en.json',
+        contents: new Buffer('{"HEADLINE":"What an awesome module!"}')
+      }));
+
+      stream.end();
+    });
+});
+
   describe('options.filename', function () {
     it('should default to translations.js if not specified', function(cb) {
       var stream = angularTranslate();


### PR DESCRIPTION
I have added a very simple change to allow adding a `preferredLanguage` through the `$translateProvider`.

I understand that a user can set this in a separate config block but I do feel it adds convenience and also encapsulation for this plugin.
