### PR TITLE
Escaping of variable content.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function cacheTranslations(options) {
 
 function wrapTranslations(options) {
   return es.map(function(file, callback) {
-    file.contents = new Buffer(gutil.template('angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n', {
+    file.contents = new Buffer(gutil.template('angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>$translateProvider.useSanitizeValueStrategy("escaped");\n}]);\n', {
       contents: file.contents,
       file: file,
       module: options.module || 'translations',


### PR DESCRIPTION
It's to use for secure strategy. Because a warning will be displayed as long as no strategy has been chosen explicitly.
