### PR TITLE
allowed dependency injection override for complex build systems.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,11 @@ function cacheTranslations(options) {
 
 function wrapTranslations(options) {
   return es.map(function(file, callback) {
-    file.contents = new Buffer(gutil.template('angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n', {
+    var template = 'angular.module("<%= module %>"<%= standalone %>).config(["$translateProvider", function($translateProvider) {\n<%= contents %>}]);\n'
+    if(options.no_di){
+      template = 'angular.module("<%= module %>").config(function($translateProvider) {\n<%= contents %>});\n';
+    }
+    file.contents = new Buffer(gutil.template(template, {
       contents: file.contents,
       file: file,
       module: options.module || 'translations',


### PR DESCRIPTION
responds to options.no_di to use a different template for gulp or other build systems which automatically insert dependency injection code. This option, where present, will use a basic module declaration which allows for externally-generated DI.
