### PR TITLE
fix: allow prefixes within the file extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function cacheTranslations(options) {
     file.contents = new Buffer(gutil.template('$translateProvider.translations("<%= language %>", <%= contents %>);\n', {
       contents: file.contents,
       file: file,
-      language: options.language || file.path.split(path.sep).pop().match(/^(?:[\w]{3,}-)?([a-z]{2}[_|-]?(?:[A-Z]{2})?)\.json$/i).pop()
+      language: options.language || file.path.split(path.sep).pop().match(/^(?:[\w]{3,}-)?([a-z]{2}[_|-]?(?:[A-Z]{2})?)(?:\..*)*\.json$/i).pop()
     }));
     callback(null, file);
   });


### PR DESCRIPTION
**foo.tr.json** or **foo.bar.foobar.json** should also get accepted.

It's fixed simply by adding a non-capturing group before `.json` part of the regex that matches with zero or more occurrence of anything ending with `.`